### PR TITLE
Probe system library when building without bundled harfbuzz

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -40,4 +40,6 @@ fn main() {
 }
 
 #[cfg(not(feature = "build-native-harfbuzz"))]
-fn main() {}
+fn main() {
+    pkg_config::probe_library("harfbuzz").unwrap();
+}


### PR DESCRIPTION
`pkg-config::probe_library` prints all relevant metadata for cargo to stdout if the search was successful.

Fixes https://github.com/harfbuzz/harfbuzz_rs/issues/49